### PR TITLE
ACM eventYear page blank page routing bug fixed

### DIFF
--- a/eventYear.php
+++ b/eventYear.php
@@ -1,3 +1,18 @@
+<?php
+$page = isset($_GET["page"]) ? $_GET["page"] : 1;
+$year = isset($_GET["year"]) ? $_GET["year"] : 2023;
+
+// Validate $year to ensure it's a valid year (optional)
+$validYears = [2019, 2020, 2021, 2022, 2023];
+if (!in_array($year, $validYears)) {
+    // Handle invalid year (you can redirect to a default year or display an error)
+    header("Location: eventYear.php?year=2023");
+    exit();
+}
+
+$previous = $page == 1 ? 1 : $page - 1;
+?>
+
 <!DOCTYPE html>
 <html lang="en">
 
@@ -35,12 +50,15 @@
             <div style="margin:auto;" id="pagination_row_2021"></div>
         </div>
     </section>
-
-    <?php
+    
+<!--    <?php 
     $page = isset($_GET["page"]) ? $_GET["page"] : 1;
     $year = $_GET["year"];
     $previous = $page == 1 ? 1 : $page - 1;
-    ?>
+
+    ?> 
+-->
+
     <script>
         let allEvents = document.getElementById("eventPage");
         if (<?php echo $year ?> != 2019 && <?php echo $year ?> != 2020 && <?php echo $year ?> != 2021 && <?php echo $year ?> != 2022 && <?php echo $year ?> != 2023) {


### PR DESCRIPTION
eventYear page routing bug fixed.

I shifted the whole header code out of the html tag because it was interfering with header.php.

In the original page header code,
$year = $_GET["year"];
only got the year from the database and did not specify what to do if it was empty.

it is replaced with,
$year = isset($_GET["year"]) ? $_GET["year"] : 2023;
this line decides whether there is a year parameter in the header or not, if not then it will be 2023.

then made an array validyears and added all the years when the events took place
then added an ' if ' statement to check whether the header has a valid year or not.
if it exceeds the valid year, the user will be redirected to the default 2023.
In the future, if there are more event years, we can just add more years and update the default header to the latest year.
$validYears = [2019, 2020, 2021, 2022, 2023];
if (!in_array($year, $validYears)) {
    header("Location: eventYear.php?year=2023");
    exit();
}

the previous code for this is still there, just commented
during my testing, it didn't affect anything.